### PR TITLE
fix: 升级依赖解决 ios18 下面只显示第一个 tab 的问题

### DIFF
--- a/V2exOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/V2exOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmartlabs/PagerTabStripView.git",
       "state" : {
-        "revision" : "69921e0c755be7ff71d1e19f70b6179e432b8b0b"
+        "revision" : "eee372609bc6ed8f777d0d0884d8e9d25074e266"
       }
     },
     {

--- a/V2exOSiOS/Views/HomeView.swift
+++ b/V2exOSiOS/Views/HomeView.swift
@@ -38,6 +38,7 @@ struct HomeView: View {
                     }
             }
             .pagerTabStripViewStyle(.scrollableBarButton(tabItemSpacing: 20))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .toolbar(.hidden, for: .automatic)
         }
     }


### PR DESCRIPTION
依赖的 tabs 组件变更：https://github.com/xmartlabs/PagerTabStripView/pull/141